### PR TITLE
Avoid deep-cloning the entire DOM on Parse()

### DIFF
--- a/parser-parse.go
+++ b/parser-parse.go
@@ -20,13 +20,19 @@ func (ps *Parser) Parse(input io.Reader, pageURL *nurl.URL) (Article, error) {
 		return Article{}, fmt.Errorf("failed to parse input: %v", err)
 	}
 
-	return ps.ParseDocument(doc, pageURL)
+	return ps.ParseAndMutate(doc, pageURL)
 }
 
 // ParseDocument parses the specified document and find the main readable content.
 func (ps *Parser) ParseDocument(doc *html.Node, pageURL *nurl.URL) (Article, error) {
 	// Clone document to make sure the original kept untouched
-	ps.doc = dom.Clone(doc, true)
+	return ps.ParseAndMutate(dom.Clone(doc, true), pageURL)
+}
+
+// ParseAndMutate is like ParseDocument, but mutates doc during parsing.
+func (ps *Parser) ParseAndMutate(doc *html.Node, pageURL *nurl.URL) (Article, error) {
+	// Clone document to make sure the original kept untouched
+	ps.doc = doc
 
 	// Reset parser data
 	ps.articleTitle = ""


### PR DESCRIPTION
The `parser.ParseDocument(doc)` function deep-clones the DOM within doc to avoid mutating it during parsing. This operation is expensive, but before it couldn't be avoided.

This introduces a new function `ParseAndMutate(doc)` which callers can use if they don't care about doc being potentially mutated. If HTML is coming from an io.Reader, for example, then it should be fine to mutate the DOM since it's being discarded anyway.

The following entry points are now using ParseAndMutate:

- parser.Parse()
- FromReader()
- FromURL()